### PR TITLE
Change publish config repo

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/bgrins/TinyColor.git"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "keywords": [
     "color",
     "parser",


### PR DESCRIPTION
From now on we should publish our packages to the github registry